### PR TITLE
Add licensing settings page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ yarn-error.log*
 next-env.d.ts
 
 .genkit/*
+product-id.txt

--- a/src/app/admin/settings/license/page.tsx
+++ b/src/app/admin/settings/license/page.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import * as React from 'react';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { KeyRound, Loader2 } from 'lucide-react';
+import { useLocale } from '@/contexts/LocaleContext';
+
+export default function LicenseSettingsPage() {
+  const { t } = useLocale();
+  const iconSize = 'h-2.5 w-2.5';
+
+  const [licenseKey, setLicenseKey] = React.useState('');
+  const [productId, setProductId] = React.useState('');
+  const [status, setStatus] = React.useState<'idle' | 'checking' | 'valid' | 'invalid' | 'error'>('idle');
+
+  React.useEffect(() => {
+    const loadId = async () => {
+      try {
+        const res = await fetch('/api/product-id');
+        if (res.ok) {
+          const data = await res.json();
+          setProductId(data.productId);
+        }
+      } catch (e) {
+        console.error('Failed to load product ID:', e);
+      }
+    };
+    loadId();
+  }, []);
+
+  const checkLicense = async () => {
+    setStatus('checking');
+    try {
+      const response = await fetch('https://auth.prolter.com/api/license/check', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ key: licenseKey, product: productId }),
+      });
+      if (!response.ok) throw new Error('server_error');
+      const data = await response.json();
+      setStatus(data.valid ? 'valid' : 'invalid');
+    } catch (e) {
+      console.error('License check failed:', e);
+      setStatus('error');
+    }
+  };
+
+  const renderStatusMessage = () => {
+    switch (status) {
+      case 'valid':
+        return t('licensing_page.license_valid', 'License is valid.');
+      case 'invalid':
+        return t('licensing_page.license_invalid', 'License is invalid.');
+      case 'error':
+        return t('licensing_page.server_unavailable', 'License server unavailable.');
+      case 'checking':
+        return t('licensing_page.checking', 'Checking license...');
+      default:
+        return '';
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex justify-between items-center">
+        <h1 className="text-base font-semibold flex items-center gap-2">
+          <KeyRound className={`${iconSize} text-primary`} />
+          {t('sidebar.settings_license', 'License')}
+        </h1>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-sm">{t('licensing_page.title', 'License Verification')}</CardTitle>
+          <CardDescription className="text-xs">{t('licensing_page.description', 'Check the validity of your license key.')}</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-1.5">
+            <label htmlFor="licenseKey" className="text-sm font-medium leading-none">
+              {t('licensing_page.input_label', 'License Key')}
+            </label>
+            <Input
+              id="licenseKey"
+              value={licenseKey}
+              onChange={(e) => setLicenseKey(e.target.value)}
+              placeholder={t('licensing_page.input_placeholder', 'Enter your license key')}
+            />
+        </div>
+        {productId && (
+          <p className="text-xs text-muted-foreground">
+            {t('licensing_page.product_number', 'Product Number')}: {productId}
+          </p>
+        )}
+        <Button type="button" onClick={checkLicense} disabled={status === 'checking'}>
+            {status === 'checking' && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            {t('licensing_page.check_button', 'Check License')}
+          </Button>
+          {status !== 'idle' && (
+            <p className="text-xs text-muted-foreground">{renderStatusMessage()}</p>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/api/product-id/route.ts
+++ b/src/app/api/product-id/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from 'next/server';
+import { promises as fs } from 'fs';
+import { join } from 'path';
+import { randomUUID } from 'crypto';
+
+const filePath = join(process.cwd(), 'product-id.txt');
+
+export async function GET() {
+  try {
+    let id: string;
+    try {
+      id = (await fs.readFile(filePath, 'utf8')).trim();
+    } catch {
+      id = randomUUID();
+      await fs.writeFile(filePath, id, 'utf8');
+    }
+    return NextResponse.json({ productId: id });
+  } catch (e) {
+    console.error('Failed to load product ID:', e);
+    return NextResponse.json({ error: 'internal_error' }, { status: 500 });
+  }
+}
+

--- a/src/config/sidebarNav.ts
+++ b/src/config/sidebarNav.ts
@@ -43,11 +43,12 @@ import {
   ShoppingCart,
   MessageCircle,
   Workflow,
-  Radio, 
-  GitMerge, 
-  Webhook, 
+  Radio,
+  GitMerge,
+  Webhook,
   Table2, // Added for Tables
   Terminal, // Added for SQL CLI
+  KeyRound,
 } from 'lucide-react';
 import type { Icon as LucideIcon } from 'lucide-react';
 import type { IconType } from 'react-icons';
@@ -581,6 +582,12 @@ export const sidebarNav: SidebarNavItem[] = [
         href: '/admin/settings/security',
         icon: ShieldCheck,
         tooltip: 'sidebar.settings_security',
+      },
+      {
+        title: 'sidebar.settings_license',
+        href: '/admin/settings/license',
+        icon: KeyRound,
+        tooltip: 'sidebar.settings_license',
       },
       {
         title: 'sidebar.settings_system_monitor',

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -43,6 +43,7 @@ import messengerConfigure from './en/messengerConfigure';
 import postgresDatabases from './en/postgresDatabases';
 import postgresTables from './en/postgresTables';
 import postgresSqlCli from './en/postgresSqlCli';
+import settingsLicense from './en/settingsLicense';
 
 
 
@@ -91,6 +92,7 @@ const en = {
   ...postgresDatabases,
   ...postgresTables,
   ...postgresSqlCli,
+  ...settingsLicense,
   
 
   form_cancel_button: 'Cancel',

--- a/src/translations/en/settingsLicense.ts
+++ b/src/translations/en/settingsLicense.ts
@@ -1,0 +1,16 @@
+//src/translations/en/settingsLicense.ts
+
+const settingsLicense = {
+  title: 'License Verification',
+  description: 'Check the validity of your license key.',
+  input_label: 'License Key',
+  input_placeholder: 'Enter your license key',
+  check_button: 'Check License',
+  checking: 'Checking license...',
+  license_valid: 'License is valid.',
+  license_invalid: 'License is invalid.',
+  server_unavailable: 'License server unavailable.',
+  product_number: 'Product Number'
+};
+
+export default settingsLicense;

--- a/src/translations/en/sidebar.ts
+++ b/src/translations/en/sidebar.ts
@@ -90,6 +90,7 @@ const sidebar = {
       settings_postgres_tables: 'Tables', // New
       settings_postgres_sql_cli: 'SQL CLI', // New
       settings_security: 'Security',
+      settings_license: 'License',
       settings_system_monitor: 'System Monitor',
       settings_integrations: 'Integrations',
       settings_integrations_whatsapp: 'WhatsApp',


### PR DESCRIPTION
## Summary
- implement admin settings page for license checking
- configure sidebar and translations for new page
- generate per-installation product ID used for license checks

## Testing
- `npm run lint` *(fails: prompts for ESLint setup)*
- `npm run typecheck` *(fails with TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68542d79c1d883298ba14a4987433ef8